### PR TITLE
test: New test for maintenanceMessage

### DIFF
--- a/cypress/e2e/maintenanceMessage.cy.ts
+++ b/cypress/e2e/maintenanceMessage.cy.ts
@@ -1,8 +1,35 @@
-describe("Test for maintenance message", () => {
-  it("Check if the maintenance message is displayed", () => {
+describe("Test for maintenance message (maintenanceMode=true)", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          maintenanceMode: "true",
+        },
+      });
+    });
     cy.visit("http://localhost:3000");
+  });
 
-    // si le site est en maintenance alors
+  it("Check if the maintenance message is displayed", () => {
     cy.get(".MuiBackdrop-root > .MuiBox-root").should("exist");
+  });
+});
+
+describe("Test for maintenance message (maintenanceMode=false)", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          maintenanceMode: "false",
+        },
+      });
+    });
+    cy.visit("http://localhost:3000");
+  });
+
+  it("Check if the maintenance message is not displayed", () => {
+    cy.get(".MuiBackdrop-root > .MuiBox-root").should("not.exist");
   });
 });

--- a/cypress/e2e/maintenanceMessage.cy.ts
+++ b/cypress/e2e/maintenanceMessage.cy.ts
@@ -1,0 +1,8 @@
+describe("Test for maintenance message", () => {
+  it("Check if the maintenance message is displayed", () => {
+    cy.visit("http://localhost:3000");
+
+    // si le site est en maintenance alors
+    cy.get(".MuiBackdrop-root > .MuiBox-root").should("exist");
+  });
+});

--- a/cypress/e2e/maintenanceMessage.cy.ts
+++ b/cypress/e2e/maintenanceMessage.cy.ts
@@ -1,15 +1,13 @@
 describe("Test for maintenance message", () => {
   context("When maintenanceMode is true", () => {
     beforeEach(() => {
-      cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
-        req.reply({
-          statusCode: 200,
-          body: {
-            maintenanceMode: "true",
-          },
-        });
+      cy.intercept("GET", "/api/maintenance", {
+        statusCode: 200,
+        body: {
+          maintenanceMode: "true",
+        },
       });
-      cy.visit("http://localhost:3000");
+      cy.visit("/");
     });
 
     it("Check if the maintenance message is displayed", () => {
@@ -19,15 +17,13 @@ describe("Test for maintenance message", () => {
 
   context("When maintenanceMode is false", () => {
     beforeEach(() => {
-      cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
-        req.reply({
-          statusCode: 200,
-          body: {
-            maintenanceMode: "false",
-          },
-        });
+      cy.intercept("GET", "/api/maintenance", {
+        statusCode: 200,
+        body: {
+          maintenanceMode: "true",
+        },
       });
-      cy.visit("http://localhost:3000");
+      cy.visit("/");
     });
 
     it("Check if the maintenance message is not displayed", () => {

--- a/cypress/e2e/maintenanceMessage.cy.ts
+++ b/cypress/e2e/maintenanceMessage.cy.ts
@@ -1,35 +1,37 @@
-describe("Test for maintenance message (maintenanceMode=true)", () => {
-  beforeEach(() => {
-    cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
-      req.reply({
-        statusCode: 200,
-        body: {
-          maintenanceMode: "true",
-        },
+describe("Test for maintenance message", () => {
+  context("When maintenanceMode is true", () => {
+    beforeEach(() => {
+      cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            maintenanceMode: "true",
+          },
+        });
       });
+      cy.visit("http://localhost:3000");
     });
-    cy.visit("http://localhost:3000");
+
+    it("Check if the maintenance message is displayed", () => {
+      cy.get(".MuiBackdrop-root > .MuiBox-root").should("exist");
+    });
   });
 
-  it("Check if the maintenance message is displayed", () => {
-    cy.get(".MuiBackdrop-root > .MuiBox-root").should("exist");
-  });
-});
-
-describe("Test for maintenance message (maintenanceMode=false)", () => {
-  beforeEach(() => {
-    cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
-      req.reply({
-        statusCode: 200,
-        body: {
-          maintenanceMode: "false",
-        },
+  context("When maintenanceMode is false", () => {
+    beforeEach(() => {
+      cy.intercept("GET", "http://localhost:3000/api/maintenance", (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            maintenanceMode: "false",
+          },
+        });
       });
+      cy.visit("http://localhost:3000");
     });
-    cy.visit("http://localhost:3000");
-  });
 
-  it("Check if the maintenance message is not displayed", () => {
-    cy.get(".MuiBackdrop-root > .MuiBox-root").should("not.exist");
+    it("Check if the maintenance message is not displayed", () => {
+      cy.get(".MuiBackdrop-root > .MuiBox-root").should("not.exist");
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "./cypress.config.ts", "./cypress/**/*"]
+  "exclude": ["node_modules", "./cypress.config.ts"]
 }


### PR DESCRIPTION
# Pull Request Summary 🚀
Add a test for maintenanceMessage. 

## Overview
Add a test for maintenanceMessage. It check if the maintenance popup is displayed when maintenanceMode is true and not displayed when maintenanceMode is false.

## Changes Made
- [ ] New features (add more details in the remarks)
- [ ] Rectified issues impacting functionality.
- [ ] Implemented optimizations for improved performance.
- [ ] Ensured code adherence to standards.
- [X] New tests

## Testing
- [ ] Updated Jest Tests if required
- [ ] Executed Jest Tests
- [ ] Updated Cypress if required
- [x] Executed Cypress Tests

## Additional Remarks
Your feedback and review are greatly appreciated.

## Review Checklist
- [ ] Addressed all issues and concerns.
- [ ] Tested thoroughly in various environments.
- [ ] Code adheres to established standards.
